### PR TITLE
Fix: function forwarding now respects target_arch

### DIFF
--- a/proxygen-macros/src/lib.rs
+++ b/proxygen-macros/src/lib.rs
@@ -106,11 +106,12 @@ pub fn forward(_attr_input: TokenStream, item: TokenStream) -> TokenStream {
         panic!("Your function body will not get run in a forwarding proxy. Perhaps you meant to use a `pre_hook`?");
     }
 
-    if cfg!(target_arch = "x86_64") {
-        TokenStream::from(quote!(
-            #[naked]
-            #(#attrs)*
-            pub unsafe extern "C" fn #func_name() {
+    TokenStream::from(quote!(
+        #[naked]
+        #(#attrs)*
+        pub unsafe extern "C" fn #func_name() {
+            #[cfg(target_arch = "x86_64")] 
+            {
                 std::arch::asm!(
                     "call {wait_dll_proxy_init}",
                     "mov rax, qword ptr [rip + {ORIG_FUNCS_PTR}]",
@@ -124,12 +125,9 @@ pub fn forward(_attr_input: TokenStream, item: TokenStream) -> TokenStream {
                     options(noreturn)
                 )
             }
-        ))
-    } else if cfg!(target_arch = "x86") {
-        TokenStream::from(quote!(
-            #[naked]
-            #(#attrs)*
-            pub unsafe extern "C" fn #func_name() {
+
+            #[cfg(target_arch = "x86")] 
+            {
                 std::arch::asm!(
                     "call {wait_dll_proxy_init}",
                     "mov eax, dword ptr [{ORIG_FUNCS_PTR}]",
@@ -138,15 +136,13 @@ pub fn forward(_attr_input: TokenStream, item: TokenStream) -> TokenStream {
                     "push eax",
                     "ret",
                     wait_dll_proxy_init = sym crate::wait_dll_proxy_init,
-                    ORIG_FUNCS_PTR = crate::ORIG_FUNCS_PTR,
-                    orig_index = #orig_index_ident,
+                    ORIG_FUNCS_PTR = sym crate::ORIG_FUNCS_PTR,
+                    orig_index = const #orig_index_ident,
                     options(noreturn)
-                );
+                )
             }
-        ))
-    } else {
-        panic!("Unsupported target arch detected. Only x86_64 and x86 are supported")
-    }
+        }
+    ))
 }
 
 // Proc macro to bring the original function into the scope of an interceptor function as `orig_func`


### PR DESCRIPTION
Fixes #1 
Had to also alter the code of x86 a bit for it to work. Was able to observe all functions exported in both x86 and x86_64 dlls.