### PR TITLE
Switch to naked_asm macros

### DIFF
--- a/proxygen-macros/src/lib.rs
+++ b/proxygen-macros/src/lib.rs
@@ -112,7 +112,7 @@ pub fn forward(_attr_input: TokenStream, item: TokenStream) -> TokenStream {
         pub unsafe extern "C" fn #func_name() {
             #[cfg(target_arch = "x86_64")]
             {
-                std::arch::asm!(
+                std::arch::naked_asm!(
                     "call {wait_dll_proxy_init}",
                     "mov rax, qword ptr [rip + {ORIG_FUNCS_PTR}]",
                     "add rax, {orig_index} * 8",
@@ -122,13 +122,12 @@ pub fn forward(_attr_input: TokenStream, item: TokenStream) -> TokenStream {
                     wait_dll_proxy_init = sym crate::wait_dll_proxy_init,
                     ORIG_FUNCS_PTR = sym crate::ORIG_FUNCS_PTR,
                     orig_index = const #orig_index_ident,
-                    options(noreturn)
                 )
             }
 
             #[cfg(target_arch = "x86")]
             {
-                std::arch::asm!(
+                std::arch::naked_asm!(
                     "call {wait_dll_proxy_init}",
                     "mov eax, dword ptr [{ORIG_FUNCS_PTR}]",
                     "add eax, {orig_index} * 4",
@@ -138,7 +137,6 @@ pub fn forward(_attr_input: TokenStream, item: TokenStream) -> TokenStream {
                     wait_dll_proxy_init = sym crate::wait_dll_proxy_init,
                     ORIG_FUNCS_PTR = sym crate::ORIG_FUNCS_PTR,
                     orig_index = const #orig_index_ident,
-                    options(noreturn)
                 )
             }
         }


### PR DESCRIPTION
In rust 1.83.0 nightly, `asm!` is no longer allowed in naked functions. switch to `naked_asm!` to fix compilation errors. 