### PR TITLE
Fix proxygen-macros build issues in latest Rust

### DIFF
--- a/proxygen-macros/src/lib.rs
+++ b/proxygen-macros/src/lib.rs
@@ -112,7 +112,7 @@ pub fn forward(_attr_input: TokenStream, item: TokenStream) -> TokenStream {
         pub unsafe extern "C" fn #func_name() {
             #[cfg(target_arch = "x86_64")]
             {
-                std::arch::asm!(
+                std::arch::naked_asm!(
                     "call {wait_dll_proxy_init}",
                     "mov rax, qword ptr [rip + {ORIG_FUNCS_PTR}]",
                     "add rax, {orig_index} * 8",
@@ -122,13 +122,12 @@ pub fn forward(_attr_input: TokenStream, item: TokenStream) -> TokenStream {
                     wait_dll_proxy_init = sym crate::wait_dll_proxy_init,
                     ORIG_FUNCS_PTR = sym crate::ORIG_FUNCS_PTR,
                     orig_index = const #orig_index_ident,
-                    options(noreturn)
                 )
             }
 
             #[cfg(target_arch = "x86")]
             {
-                std::arch::asm!(
+                std::arch::naked_asm!(
                     "call {wait_dll_proxy_init}",
                     "mov eax, dword ptr [{ORIG_FUNCS_PTR}]",
                     "add eax, {orig_index} * 4",
@@ -138,7 +137,6 @@ pub fn forward(_attr_input: TokenStream, item: TokenStream) -> TokenStream {
                     wait_dll_proxy_init = sym crate::wait_dll_proxy_init,
                     ORIG_FUNCS_PTR = sym crate::ORIG_FUNCS_PTR,
                     orig_index = const #orig_index_ident,
-                    options(noreturn)
                 )
             }
         }
@@ -254,7 +252,7 @@ pub fn pre_hook(attr_input: TokenStream, item: TokenStream) -> TokenStream {
                 #[naked]
                 #(#attrs)*
                 pub unsafe extern "C" fn #func_name() {
-                    std::arch::asm!(
+                    std::arch::naked_asm!(
                         // Wait for dll proxy to initialize
                         "call {wait_dll_proxy_init}",
                         "mov rax, qword ptr [rip + {ORIG_FUNCS_PTR}]",
@@ -293,7 +291,6 @@ pub fn pre_hook(attr_input: TokenStream, item: TokenStream) -> TokenStream {
                         ORIG_FUNCS_PTR = sym crate::ORIG_FUNCS_PTR,
                         orig_index = const #orig_index_ident,
                         proxygen_pre_hook_func = sym #hook_func_name,
-                        options(noreturn)
                     );
                 }
             ))


### PR DESCRIPTION
This pull request updates the `proxygen-macros` crate to use the new `std::arch::naked_asm!` macro instead of the deprecated `std::arch::asm!` for naked functions. The change is applied across both the `forward` and `pre_hook` macro implementations, ensuring compatibility with the latest Rust conventions for inline assembly in naked functions. Additionally, the unnecessary `options(noreturn)` directive is removed from the assembly blocks.

**Migration to `naked_asm!` macro:**

* Replaced all uses of `std::arch::asm!` with `std::arch::naked_asm!` in the `forward` and `pre_hook` macro-generated functions to align with updated Rust requirements for naked functions. [[1]](diffhunk://#diff-460977604ba3ef84ec4431ddc4cf9f5fdee82e98cb28fc1926dc6d973891a0a9L115-R115) [[2]](diffhunk://#diff-460977604ba3ef84ec4431ddc4cf9f5fdee82e98cb28fc1926dc6d973891a0a9L125-R130) [[3]](diffhunk://#diff-460977604ba3ef84ec4431ddc4cf9f5fdee82e98cb28fc1926dc6d973891a0a9L257-R255)

**Assembly options cleanup:**

* Removed the `options(noreturn)` directive from the inline assembly blocks, as it is not needed with `naked_asm!` and may be incompatible. [[1]](diffhunk://#diff-460977604ba3ef84ec4431ddc4cf9f5fdee82e98cb28fc1926dc6d973891a0a9L125-R130) [[2]](diffhunk://#diff-460977604ba3ef84ec4431ddc4cf9f5fdee82e98cb28fc1926dc6d973891a0a9L141) [[3]](diffhunk://#diff-460977604ba3ef84ec4431ddc4cf9f5fdee82e98cb28fc1926dc6d973891a0a9L296)